### PR TITLE
fix(render): replace links where only href differs

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -22,9 +22,19 @@ function meta(node: ChildNode, head: HTMLElement) {
   }
 }
 
-function link(node: ChildNode) {
+function link(node: ChildNode, head: HTMLElement) {
   if (!hasChildren(node)) {
-    return createElement(node);
+    const attrsSelector = Object.keys(node.vattrs)
+                                .filter(namePropKey => namePropKey !== "href")
+                                .map(namePropKey => `[${namePropKey}="${node.vattrs[namePropKey]}"]`)
+                                .join("");
+
+    const existingElement = head.querySelector(`link${attrsSelector}`);
+    if (existingElement !== null) {
+      return [createElement(node), existingElement];
+    } else {
+      return createElement(node);
+    }
   }
 }
 

--- a/test/render.spec.ts
+++ b/test/render.spec.ts
@@ -54,8 +54,9 @@ describe('link', () => {
   const linkNode: ChildNode = {
     vtag: 'link',
     vattrs: {
-      name: 'foo',
-      content: 'bar'
+      rel: 'alternate',
+      hreflang: 'en',
+      href: 'https://en.example.com/'
     },
     vchildren: null,
     vtext: null
@@ -71,7 +72,19 @@ describe('link', () => {
   });
 
   it('should render an element', () => {
-    expect(RenderTypes.link(linkNode))
+    expect(RenderTypes.link(linkNode, document.head))
+      .toBeInstanceOf(HTMLElement);
+  });
+
+  it('should return two elements with a match regardless of href', () => {
+    document.head.innerHTML = `<link rel="alternate" hreflang="en" href="https://en.example.com/page"/>`;
+    expect(RenderTypes.link(linkNode, document.head))
+      .toHaveLength(2);
+  });
+
+  it('should not return two elements if anything other than href differs', () => {
+    document.head.innerHTML = `<link rel="alternate" hreflang="es" href="https://es.example.com/page"/>`;
+    expect(RenderTypes.link(linkNode, document.head))
       .toBeInstanceOf(HTMLElement);
   });
 });


### PR DESCRIPTION
This replaces link tags with same attributes if only `href` differs instead of adding duplicates. This is useful for for example `canonical` or `alternate` where you want to replace the previous value rather than just adding more and more.