### PR TITLE
chore(repo): migrate project to stencil-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![@stencil/helmet](https://img.shields.io/npm/v/@stencil/helmet.svg)](https://npm.im/@stencil/helmet)
+[![@stencil-community/helmet](https://img.shields.io/npm/v/@stencil-community/helmet.svg)](https://npm.im/@stencil-community/helmet)
 
 # Stencil Helmet
 
@@ -13,13 +13,13 @@ This is a [Stencil](https://github.com/ionic-team/stencil) component meant to be
 ## Installation
 
 ```
-npm install @stencil/helmet
+npm install @stencil-community/helmet
 ```
 
 ## Usage
 
 ```jsx
-import Helmet from '@stencil/helmet';
+import Helmet from '@stencil-community/helmet';
 
 //...
 export class MyComponent {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stencil/helmet",
+  "name": "@stencil-community/helmet",
   "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stencil/helmet",
+  "name": "@stencil-community/helmet",
   "version": "0.3.3",
   "description": "Declaratively update the head from a Stencil app.",
   "main": "dist/stencil-helmet.js",
@@ -15,13 +15,13 @@
   },
   "author": "Ionic Team",
   "license": "MIT",
-  "homepage": "https://github.com/ionic-team/stencil-helmet",
+  "homepage": "https://github.com/stencil-community/stencil-helmet",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ionic-team/stencil-helmet.git"
+    "url": "git+https://github.com/stencil-community/stencil-helmet.git"
   },
   "bugs": {
-    "url": "https://github.com/ionic-team/stencil-helmet"
+    "url": "https://github.com/stencil-community/stencil-helmet"
   },
   "devDependencies": {
     "@stencil/core": "^2.3.0",


### PR DESCRIPTION
this commit updates the project to migrate it to the stencil community. specifically, it:
- updates the scope of the project from `@stencil/` to `@stencil-community/`, in order to publish the project under that npm organization
- fixes up links to the projects to point to the new url in github (now that the project is under the stencil-community github org). if any links were missed, github should redirect them anyway